### PR TITLE
Allow setting plugin options

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -166,6 +166,7 @@ class Config {
     _filter(name, this.args, child.args);
     _filter(name, this.query, child.query);
     _filter(name, this.hash, child.hash);
+    _filter(name, this.options, child.options);
 
     return child;
   }


### PR DESCRIPTION
Allow passing "plugin-option" keys to the options of a new node and
have these options propagated to the specified plugin. Only works
with the wallet plugin.