### PR TITLE
Allow passing of custom child configs to filter

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -42,6 +42,7 @@ class Config {
     this.pass = [];
     this.query = Object.create(null);
     this.hash = Object.create(null);
+    this.child = Object.create(null);
 
     if (options)
       this.init(options);
@@ -91,6 +92,7 @@ class Config {
         case 'env':
         case 'argv':
         case 'config':
+        case 'child':
           continue;
       }
 
@@ -116,7 +118,17 @@ class Config {
     if (options.argv)
       this.parseArg(options.argv);
 
+    if (options.child)
+      this.parseChild(options.child);
+
     this.prefix = this.getPrefix();
+  }
+
+  parseChild(options) {
+    for (const key of Object.keys(options)) {
+      const value = options[key];
+      this.child[key.toLowerCase()] = value;
+    }
   }
 
   /**
@@ -162,6 +174,7 @@ class Config {
     child.argv = this.argv;
     child.pass = this.pass;
 
+    _filter(name, this.child, child.options);
     _filter(name, this.env, child.env);
     _filter(name, this.args, child.args);
     _filter(name, this.query, child.query);


### PR DESCRIPTION
This is an alternative to PR #1 which has some concerns regarding name spacing.

This is required for this related PR:
https://github.com/bcoin-org/bcoin/pull/562