### PR TITLE
Allow for multiple layered config files

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -121,26 +121,30 @@ class Config {
 
   /**
    * Open a config file.
-   * @param {String} file - e.g. `bcoin.conf`.
+   * @param {String/Array} file - e.g. `bcoin.conf`, or array of strings
    * @throws on IO error
    */
 
-  open(file) {
+  open(files) {
     if (fs.unsupported)
       return;
 
-    const path = this.getFile(file);
+    files = !Array.isArray(files) ? [files] : files;
 
-    let text;
-    try {
-      text = fs.readFileSync(path, 'utf8');
-    } catch (e) {
-      if (e.code === 'ENOENT')
-        return;
-      throw e;
+    for (const file of files) {
+        const path = this.getFile(file);
+
+        let text;
+        try {
+          text = fs.readFileSync(path, 'utf8');
+        } catch (e) {
+          if (e.code === 'ENOENT')
+            break;
+          throw e;
+        }
+
+        this.parseConfig(text);
     }
-
-    this.parseConfig(text);
 
     this.prefix = this.getPrefix();
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -121,7 +121,7 @@ class Config {
 
   /**
    * Open a config file.
-   * @param {String/Array} file - e.g. `bcoin.conf`, or array of strings
+   * @param {String|String[]} file - e.g. `bcoin.conf`, or array of strings
    * @throws on IO error
    */
 
@@ -139,7 +139,7 @@ class Config {
           text = fs.readFileSync(path, 'utf8');
         } catch (e) {
           if (e.code === 'ENOENT')
-            break;
+            continue;
           throw e;
         }
 


### PR DESCRIPTION
Fairly small change that allows for lots of useful functionality. Allows for layers of configuration to be included easily, or to specify "fallback" configurations for backwards compatibility.

**Caveat:**
I'm not a huge fan of allowing both strings & arrays in the same parameter, but this was the path to making the fewest code changes. Alternatively could keep `open` the same and create a new `openMulti` call that accepts an array.

This is useful for bcoin-org/bcoin#556
