### PR TITLE
add data to child creation in filter

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -166,6 +166,7 @@ class Config {
     _filter(name, this.args, child.args);
     _filter(name, this.query, child.query);
     _filter(name, this.hash, child.hash);
+    _filter(name, this.data, child.data);
 
     return child;
   }


### PR DESCRIPTION
Currently, in the wallet plugin in hsd reading prefixed configuration values from the main hsd.conf file is not working. 

The values are being parsed, but they are stored in this.data inside of config.

Relevant code: https://github.com/handshake-org/hsd/blob/master/lib/wallet/plugin.js#L36

If you console.log(node.config) in this file, you will see that you value exists, but is stored in data. 

e.g: `this.data = {"wallethttpport": 1234}`

If you console.log(this.config) after the filter command, wallethttpport or httpport does not exist in the object. I believe that this addition will ensure that prefixed variable names are working from the main configuration file. 

Tested locally on the wallet plugin, and I can confirm that this does fix the issue. 