### PR TITLE
config: pass and filter JSON options to child

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -166,6 +166,7 @@ class Config {
     _filter(name, this.args, child.args);
     _filter(name, this.query, child.query);
     _filter(name, this.hash, child.hash);
+    _filter(name, this.options, child.options);
 
     return child;
   }

--- a/test/bcfg-test.js
+++ b/test/bcfg-test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const assert = require('bsert');
+const Config = require('../lib/config');
+
+describe('bcfg', function() {
+  it('should filter options', () => {
+    const options = {
+      testString: 'hello',
+      childTestString: 'goodbye'
+    };
+
+    const parent = new Config('bcfg');
+    parent.inject(options);
+    parent.load(options);
+
+    assert.strictEqual(parent.str('test-string'), 'hello');
+
+    const child = parent.filter('child');
+
+    assert.strictEqual(child.str('test-string'), 'goodbye');
+  });
+
+  it('should filter argv', () => {
+    const parent = new Config('bcfg');
+
+    // process.argv
+    parent.parseArg([
+      'node',
+      'bcfg',
+      '--test-string=hello',
+      '--child-test-string=goodbye'
+    ]);
+
+    assert.strictEqual(parent.str('test-string'), 'hello');
+
+    const child = parent.filter('child');
+
+    assert.strictEqual(child.str('test-string'), 'goodbye');
+  });
+});


### PR DESCRIPTION
Allows this configuration to pass the filtered option `migrate` to child config `wallet`:

```
const node = new FullNode({
  walletMigrate: 1
});
```