### PR TITLE
Use last used prefix

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -760,7 +760,7 @@ class Config {
       if (prefix[0] === '~')
         prefix = Path.join(HOME, prefix.substring(1));
     } else {
-      prefix = Path.join(HOME, `.${this.module}`);
+      prefix = this.prefix;
     }
 
     if (this.suffix) {


### PR DESCRIPTION
if there's no prefix passed in the options, use last set prefix.

This solves problem for hsd and bcoin when you pass `--prefix` plugins don't inherit it. Now plugins will use prefix from `hsd` or `bcoin` unless it was overridden by the plugin config.

E.g. `hsd --prefix=/tmp/dir` - will create hsd directory there, but wallet will go to the `~/.hsd/`. Now, it will stick with node.
Worse case was with network: `hsd --prefix=/tmp/dir` will create wallet in `~/.hsd/wallet` instead, because `network` option is not passed down to the wallet, so suffix can't be correctly generated. (even with the incorrect prefix, should have been `~/hsd/regtest/wallet`.

Suffix issue needs fixing in the hsd/bcoin `lib/wallet/plugin.js`.